### PR TITLE
Limits the list of suppliers to suppliers active in adding supplier prices

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -505,7 +505,7 @@ if ($id > 0 || $ref) {
 				} else {
 					$events = array();
 					$events[] = array('method' => 'getVatRates', 'url' => dol_buildpath('/core/ajax/vatrates.php', 1), 'htmlname' => 'tva_tx', 'params' => array());
-					$filter = '(fournisseur:=:1)';
+					$filter = '(fournisseur:=:1) AND (status:=:1)';
 					print img_picto('', 'company', 'class="pictofixedwidth"').$form->select_company(GETPOST("id_fourn", 'alpha'), 'id_fourn', $filter, 'SelectThirdParty', 0, 0, $events);
 
 					$parameters = array('filtre'=>"fournisseur=1", 'html_name'=>'id_fourn', 'selected'=>GETPOST("id_fourn"), 'showempty'=>1, 'prod_id'=>$object->id);


### PR DESCRIPTION
Closed supplier prices are hidden in the product/fournisseurs.php tab

In the same philosophy I filtered the companies from the drop-down list when adding supplier prices in order to only display active suppliers.