### PR TITLE
Update facture.class.php add missing class_element_line property

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -76,6 +76,11 @@ class Facture extends CommonInvoice
 	public $table_element_line = 'facturedet';
 
 	/**
+	 * @var string Name of class line
+	 */
+	public $class_element_line = 'FactureLigne';
+	
+	/**
 	 * @var string Fieldname with ID of parent key if this field has a parent
 	 */
 	public $fk_element = 'fk_facture';


### PR DESCRIPTION
QUAL Adding missing property in facture.class.php 
in order to standardize with other classes such as the Commande class, I added the class_element_line property in the Facture class
